### PR TITLE
use the new Python 3.4 Docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
-FROM zalando/ubuntu:14.04.1-1
+FROM zalando/python:3.4.0-1
 MAINTAINER fabian.wollert@zalando.de teng.qiu@zalando.de
 
 ENV ZOOKEEPER_VERSION="3.4.6"
 
 RUN apt-get update
-RUN apt-get install python3 python3-pip wget openjdk-7-jre -y --force-yes
-RUN easy_install-3.4 pip
+RUN apt-get install wget openjdk-7-jre -y --force-yes
 RUN pip3 install boto3
 
 ADD download_zookeeper.sh /tmp/download_zookeeper.sh

--- a/adapt_config_and_start.sh
+++ b/adapt_config_and_start.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 echo "checking for other nodes ..."
-python3 /tmp/find_out_other_zk_hosts.py -f /opt/zookeeper-${ZOOKEEPER_VERSION}/conf/zoo.cfg -d /var/zookeeper
+/tmp/find_out_other_zk_hosts.py -f /opt/zookeeper-${ZOOKEEPER_VERSION}/conf/zoo.cfg -d /var/zookeeper
 echo "edited other nodes into config"
 
 echo "starting Zookeeper now ..."

--- a/find_out_other_zk_hosts.py
+++ b/find_out_other_zk_hosts.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import boto3
 from boto3.session import Session
 import requests


### PR DESCRIPTION
using our Zalando Python base image makes it easier and faster to upgrade (as the Python install is already done by the base image)